### PR TITLE
feat: Run tests as root user

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
       # the one of the container the tests run on.
       # You can switch this base image with a custom image tailored to your project
       image: ckan/ckan-dev:2.11
+      options: --user root
     services:
       solr:
         image: ckan/ckan-solr:2.11-solr9


### PR DESCRIPTION
This is necessary to run tests on the new CKAN containers (as of https://github.com/ckan/ckan-docker/pull/172) and apparently also to use the `actions/checkout` action (see https://github.com/actions/checkout/issues/956#event-19310827173).